### PR TITLE
Fix amount field using phone keyboard instead of numeric keyboard

### DIFF
--- a/lib/records/edit-record-page.dart
+++ b/lib/records/edit-record-page.dart
@@ -607,7 +607,10 @@ class EditRecordPageState extends State<EditRecordPage> {
                   style: TextStyle(
                       fontSize: 32.0,
                       color: Theme.of(context).colorScheme.onSurface),
-                  keyboardType: TextInputType.phone,
+                  keyboardType: TextInputType.numberWithOptions(
+                      signed: true,
+                      decimal: true,
+                  ),
                   decoration: InputDecoration(
                       floatingLabelBehavior: FloatingLabelBehavior.always,
                       hintText: "0",


### PR DESCRIPTION
Closes #219.

Should maintain functionality by requesting signed (`+` and `-`) and decimal characters.