### PR TITLE
fix: remove 5-year date limit from date range picker

### DIFF
--- a/.prgenie-summary.json
+++ b/.prgenie-summary.json
@@ -1,0 +1,4 @@
+{
+  "pr_title": "fix: remove 5-year date limit from date range picker",
+  "pr_content": "## Summary\n\nRemoves the artificial 5-year limit on the date range picker's `firstDate`, allowing users with more than 5 years of data (e.g., imported from CSV exports spanning 10+ years) to search across their full history.\n\n### Changes\n\n- **`lib/records/components/tab_records_date_picker.dart`**: Changed `_pickDateRange`'s `firstDate` from `DateTime(currentDate.year - 5, currentDate.month)` to `DateTime(1970)`, removing the arbitrary 5-year cap. This is consistent with other date pickers in the app (e.g., `edit-record-page.dart` uses `DateTime(1970)`).\n\nFixes #364"
+}

--- a/.prgenie-summary.json
+++ b/.prgenie-summary.json
@@ -1,4 +1,0 @@
-{
-  "pr_title": "fix: remove 5-year date limit from date range picker",
-  "pr_content": "## Summary\n\nRemoves the artificial 5-year limit on the date range picker's `firstDate`, allowing users with more than 5 years of data (e.g., imported from CSV exports spanning 10+ years) to search across their full history.\n\n### Changes\n\n- **`lib/records/components/tab_records_date_picker.dart`**: Changed `_pickDateRange`'s `firstDate` from `DateTime(currentDate.year - 5, currentDate.month)` to `DateTime(1970)`, removing the arbitrary 5-year cap. This is consistent with other date pickers in the app (e.g., `edit-record-page.dart` uses `DateTime(1970)`).\n\nFixes #364"
-}

--- a/lib/records/components/tab_records_date_picker.dart
+++ b/lib/records/components/tab_records_date_picker.dart
@@ -150,7 +150,7 @@ class TabRecordsDatePicker extends StatelessWidget {
   Future<void> _pickDateRange(BuildContext context) async {
     DateTime currentDate = DateTime.now();
     DateTime lastDate = DateTime(currentDate.year + 1, currentDate.month + 1);
-    DateTime firstDate = DateTime(currentDate.year - 5, currentDate.month);
+    DateTime firstDate = DateTime(1970);
     DateTimeRange initialDateTimeRange = DateTimeRange(
       start: DateTime.now().subtract(Duration(days: 7)),
       end: currentDate,


### PR DESCRIPTION
## Summary

Removes the artificial 5-year limit on the date range picker's `firstDate`, allowing users with more than 5 years of data (e.g., imported from CSV exports spanning 10+ years) to search across their full history.

### Changes

- **`lib/records/components/tab_records_date_picker.dart`**: Changed `_pickDateRange`'s `firstDate` from `DateTime(currentDate.year - 5, currentDate.month)` to `DateTime(1970)`, removing the arbitrary 5-year cap. This is consistent with other date pickers in the app (e.g., `edit-record-page.dart` uses `DateTime(1970)`).

Fixes #364