### PR TITLE
Fix multi-word search breaking with spaces in query

### DIFF
--- a/lib/records/controllers/tab_records_controller.dart
+++ b/lib/records/controllers/tab_records_controller.dart
@@ -2,6 +2,7 @@ import 'dart:developer';
 import 'dart:io';
 
 import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:piggybank/utils/constants.dart';
@@ -142,10 +143,10 @@ class TabRecordsController {
       tempRecords = records.where((record) {
         bool matchesSearch = !hasSearch;
         if (hasSearch) {
-          matchesSearch = _matchesSmartSearch(record?.title, query) ||
-              _matchesSmartSearch(record?.description, query) ||
-              _matchesSmartSearch(record?.category?.name, query) ||
-              _matchesSmartSearch(record?.tags.join(" "), query);
+          matchesSearch = matchesSmartSearch(record?.title, query) ||
+              matchesSmartSearch(record?.description, query) ||
+              matchesSmartSearch(record?.category?.name, query) ||
+              matchesSmartSearch(record?.tags.join(" "), query);
         }
 
         // Categories
@@ -200,19 +201,28 @@ class TabRecordsController {
     }
   }
 
-  bool _matchesSmartSearch(String? text, String query) {
-    if (text == null || text.isEmpty) return false;
+  @visibleForTesting
+  bool matchesSmartSearch(String? text, String query) {
+    if (text == null || text.isEmpty || query.isEmpty) return false;
 
     final textLower = text.toLowerCase();
+    final queryLower = query.toLowerCase();
 
-    // Split the text into words (handling multiple spaces, punctuation, etc.)
+    // Split both the text and query into words (handling multiple spaces, punctuation, etc.)
     final words = textLower
         .split(RegExp(r'[\s\-_.,;:!?()]+'))
         .where((word) => word.isNotEmpty)
         .toList();
 
-    // Check if any word starts with the query
-    return words.any((word) => word.startsWith(query));
+    final queryTerms = queryLower
+        .split(RegExp(r'[\s\-_.,;:!?()]+'))
+        .where((term) => term.isNotEmpty)
+        .toList();
+
+    if (words.isEmpty || queryTerms.isEmpty) return false;
+
+    // All query terms must match at least one word (AND logic)
+    return queryTerms.every((term) => words.any((word) => word.startsWith(term)));
   }
 
   // Data fetching

--- a/test/tab_records_controller_test.dart
+++ b/test/tab_records_controller_test.dart
@@ -61,6 +61,81 @@ void main() {
     controller = TabRecordsController(onStateChanged: () {});
   });
 
+  group('matchesSmartSearch', () {
+    test('should match single word query', () {
+      expect(controller.matchesSmartSearch('Product Name A', 'product'),
+          isTrue);
+    });
+
+    test('should match multi-word query (all words match)', () {
+      expect(
+          controller.matchesSmartSearch('Product Name A', 'product name'),
+          isTrue);
+    });
+
+    test('should match partial second word query', () {
+      expect(
+          controller.matchesSmartSearch('Product Name A', 'product n'),
+          isTrue);
+    });
+
+    test('should match when query has only start of each word', () {
+      expect(
+          controller.matchesSmartSearch('Product Name A', 'pro nam'),
+          isTrue);
+    });
+
+    test('should match case-insensitively with multi-word query', () {
+      expect(
+          controller.matchesSmartSearch('PRODUCT NAME A', 'product name'),
+          isTrue);
+    });
+
+    test('should match description field with multi-word query', () {
+      expect(
+          controller.matchesSmartSearch(
+              'Gas station purchase', 'gas station'),
+          isTrue);
+    });
+
+    test(
+        'should not match when one query term does not match any word', () {
+      expect(
+          controller.matchesSmartSearch('Product Name A', 'product xyz'),
+          isFalse);
+    });
+
+    test('should not match when no words match', () {
+      expect(controller.matchesSmartSearch('Product Name A', 'xyz'),
+          isFalse);
+    });
+
+    test('should return false for null text', () {
+      expect(controller.matchesSmartSearch(null, 'query'), isFalse);
+    });
+
+    test('should return false for empty text', () {
+      expect(controller.matchesSmartSearch('', 'query'), isFalse);
+    });
+
+    test('should return false for empty query', () {
+      expect(
+          controller.matchesSmartSearch('Product Name A', ''), isFalse);
+    });
+
+    test('should match with hyphenated words', () {
+      expect(
+          controller.matchesSmartSearch(
+              'well-known brand', 'well brand'),
+          isTrue);
+    });
+
+    test('should match single word against partial word', () {
+      expect(controller.matchesSmartSearch('Product Name A', 'prod'),
+          isTrue);
+    });
+  });
+
   group('shiftMonthWeekYear', () {
     test(
         'should shift month forward by 1 with custom interval set to a full month',
@@ -187,7 +262,7 @@ void main() {
         PreferencesKeys.homepageTimeInterval,
         HomepageTimeInterval.CurrentWeek.index,
       );
-      // Pin firstDayOfWeek to Monday so getStartOfWeek() is deterministic
+      // Pin firstDayOfWeek to Monday so getFirstDayOfWeekIndex() is deterministic
       // regardless of I18n.locale state (which may be altered by other test files).
       await sharedPreferences.setInt(
         PreferencesKeys.firstDayOfWeek,


### PR DESCRIPTION
## Summary

Fixes #366 — Search breaks with multi-word queries. Typing a space and a second word (e.g., "Product N") returned zero results even when matching records existed.

## Root Cause

The `_matchesSmartSearch` method in `tab_records_controller.dart` split the record text into individual words but treated the **entire user query** as a single atomic string. For example, searching "gas station" would check `"gas".startsWith("gas station")` and `"station".startsWith("gas station")` — both returning `false`.

## Fix

Split the query into individual search terms too, then require **all** terms to match at least one word in the text (AND logic). This way:
- `"Product"` → matches any word starting with "Product" (unchanged)
- `"Product N"` → matches if any word starts with "Product" AND any word starts with "N"
- `"gas station"` → matches if any word starts with "gas" AND any word starts with "station"

## Changes

### `lib/records/controllers/tab_records_controller.dart`
- Added `import 'package:flutter/foundation.dart' show visibleForTesting;`
- Renamed `_matchesSmartSearch` → `matchesSmartSearch` with `@visibleForTesting` annotation to allow direct unit testing
- Rewrote the method to split both `text` and `query` into words, then use `queryTerms.every(...)` for AND-based matching

### `test/tab_records_controller_test.dart`
- Added 13 new tests covering:
  - Single-word queries (regression)
  - Multi-word queries (all words match)
  - Partial second word (the exact bug scenario: "Product N")
  - Partial matching on all terms ("pro nam")
  - Case-insensitive multi-word matching
  - Description field matching
  - Negative cases (partial match failure, no match)
  - Edge cases (null/empty text, empty query)
  - Hyphenated words

## Testing

All 668 existing tests continue to pass. The 13 new tests specifically verify the multi-word search fix.