### PR TITLE
fix: show transfers when filtering by destination wallet

### DIFF
--- a/lib/models/record.dart
+++ b/lib/models/record.dart
@@ -27,6 +27,10 @@ class Record extends Model {
   // Flag to indicate if this is a future record (not persisted to database)
   bool isFutureRecord = false;
 
+  // Transient: true when this copy represents the destination wallet's view of
+  // a transfer (value = received amount, walletId = destination). Not persisted.
+  bool isDestinationTransferView = false;
+
   Record(
     this.value,
     this.title,
@@ -101,6 +105,44 @@ class Record extends Model {
   }
 
   bool get isTransfer => transferWalletId != null;
+
+  Record copyWith({
+    int? id,
+    double? value,
+    String? title,
+    String? description,
+    Category? category,
+    Set<String>? tags,
+    DateTime? utcDateTime,
+    String? timeZoneName,
+    String? recurrencePatternId,
+    int? walletId,
+    int? transferWalletId,
+    double? transferValue,
+    int? profileId,
+    bool? isFutureRecord,
+    bool? isDestinationTransferView,
+  }) {
+    final copy = Record(
+      value ?? this.value,
+      title ?? this.title,
+      category ?? this.category,
+      utcDateTime ?? this.utcDateTime,
+      id: id ?? this.id,
+      description: description ?? this.description,
+      recurrencePatternId: recurrencePatternId ?? this.recurrencePatternId,
+      timeZoneName: timeZoneName ?? this.timeZoneName,
+      walletId: walletId ?? this.walletId,
+      transferWalletId: transferWalletId ?? this.transferWalletId,
+      transferValue: transferValue ?? this.transferValue,
+      profileId: profileId ?? this.profileId,
+      tags: tags ?? this.tags,
+      isFutureRecord: isFutureRecord ?? this.isFutureRecord,
+    );
+    copy.isDestinationTransferView =
+        isDestinationTransferView ?? this.isDestinationTransferView;
+    return copy;
+  }
 
   Map<String, dynamic> toCsvMap({Map<int, String>? walletNames}) {
     final walletName =

--- a/lib/records/components/records-per-day-card.dart
+++ b/lib/records/components/records-per-day-card.dart
@@ -109,8 +109,13 @@ class _RecordsPerDayCardState extends State<RecordsPerDayCard>
         record.walletId != null ? _walletsById[record.walletId] : null;
 
     final effectiveMap = _effectiveCurrencyMap;
-    final recordCurrency = record.walletId != null
-        ? effectiveMap[record.walletId]
+    // For destination-view copies, the received amount is in the destination
+    // wallet's currency, so look up transferWalletId instead of walletId.
+    final currencyWalletId = record.isDestinationTransferView
+        ? record.transferWalletId
+        : record.walletId;
+    final recordCurrency = currencyWalletId != null
+        ? effectiveMap[currencyWalletId]
         : wallet?.currency;
 
     final color = _amountColor(record);
@@ -249,13 +254,19 @@ class _RecordsPerDayCardState extends State<RecordsPerDayCard>
           ? () => widget.onRecordTapped?.call(movement.id!)
           : !widget.isSelectMode
               ? () async {
+                  // Destination-view copies carry a modified value (received
+                  // amount, not original) — always edit the canonical DB record.
+                  final recordToEdit = movement.isDestinationTransferView &&
+                          movement.id != null
+                      ? (await _database.getRecordById(movement.id!)) ??
+                          movement
+                      : movement;
                   await Navigator.push(
                       context,
                       MaterialPageRoute(
                           builder: (context) => EditRecordPage(
-                                passedRecord: movement,
-                                readOnly: movement
-                                    .isFutureRecord, // Future records are read-only
+                                passedRecord: recordToEdit,
+                                readOnly: movement.isFutureRecord,
                               )));
                   if (widget.onListBackCallback != null)
                     await widget.onListBackCallback!();

--- a/lib/records/controllers/tab_records_controller.dart
+++ b/lib/records/controllers/tab_records_controller.dart
@@ -191,14 +191,50 @@ class TabRecordsController {
     // Wallet filter
     if (selectedWallets.isNotEmpty) {
       final selectedIds = selectedWallets.map((w) => w.id).toSet();
-      tempRecords =
-          tempRecords.where((r) => selectedIds.contains(r?.walletId)).toList();
+      tempRecords = applyTransferAwareWalletFilter(tempRecords, selectedIds);
     }
 
     if (!const DeepCollectionEquality().equals(filteredRecords, tempRecords)) {
       filteredRecords = tempRecords;
       onStateChanged();
     }
+  }
+
+  /// Filters [records] to those belonging to [selectedWalletIds], treating
+  /// transfers as visible from both source and destination perspectives.
+  ///
+  /// - Source match: include the record unchanged (negative value, money out).
+  /// - Destination-only match: include a copy with [value] set to the received
+  ///   amount ([transferValue] for cross-currency, otherwise `value.abs()`).
+  ///   [isDestinationTransferView] is set to true so the UI resolves the
+  ///   display currency from [transferWalletId] instead of [walletId].
+  /// - Both wallets selected: include once via the source match (no duplicate).
+  @visibleForTesting
+  static List<Record?> applyTransferAwareWalletFilter(
+    List<Record?> records,
+    Set<int?> selectedWalletIds,
+  ) {
+    final result = <Record?>[];
+    for (final r in records) {
+      final matchesSource = selectedWalletIds.contains(r?.walletId);
+      final matchesDest = r?.isTransfer == true &&
+          selectedWalletIds.contains(r?.transferWalletId);
+
+      if (matchesSource) {
+        result.add(r);
+      } else if (matchesDest) {
+        // Show from destination perspective: use the received amount as value.
+        // transferValue holds the destination-currency amount for cross-currency
+        // transfers; fall back to value.abs() for same-currency ones.
+        final receivedAmount =
+            r!.transferValue ?? (r.value != null ? r.value!.abs() : null);
+        result.add(r.copyWith(
+          value: receivedAmount,
+          isDestinationTransferView: true,
+        ));
+      }
+    }
+    return result;
   }
 
   @visibleForTesting
@@ -457,9 +493,8 @@ class TabRecordsController {
         filterRecords();
         // Also filter overview records if they were fetched separately
         if (overviewRecords != null) {
-          overviewRecords = overviewRecords!
-              .where((r) => idSet.contains(r?.walletId))
-              .toList();
+          overviewRecords =
+              applyTransferAwareWalletFilter(overviewRecords!, idSet);
         }
         return;
       }

--- a/test/tab_records_controller_test.dart
+++ b/test/tab_records_controller_test.dart
@@ -4,6 +4,7 @@ import 'package:intl/date_symbol_data_local.dart';
 import 'package:piggybank/helpers/datetime-utility-functions.dart';
 import 'package:piggybank/models/category-type.dart';
 import 'package:piggybank/models/category.dart';
+import 'package:piggybank/models/record.dart';
 import 'package:piggybank/records/controllers/tab_records_controller.dart';
 import 'package:piggybank/services/database/database-interface.dart';
 import 'package:piggybank/services/service-config.dart';
@@ -463,6 +464,185 @@ void main() {
       // February only has 29 days in 2024. Start should be Feb 29.
       expect(controller.customIntervalFrom!.month, 2);
       expect(controller.customIntervalFrom!.day, 29);
+    });
+  });
+
+  group('_applyTransferAwareWalletFilter', () {
+    final expenseCategory = Category(
+      'Expense',
+      iconCodePoint: 1,
+      categoryType: CategoryType.expense,
+      color: Colors.red,
+    );
+    final incomeCategory = Category(
+      'Income',
+      iconCodePoint: 2,
+      categoryType: CategoryType.income,
+      color: Colors.green,
+    );
+
+    Record expense({required int walletId, required double value}) => Record(
+          value,
+          'Expense',
+          expenseCategory,
+          DateTime(2026, 6, 1).toUtc(),
+          walletId: walletId,
+        );
+
+    Record income({required int walletId, required double value}) => Record(
+          value,
+          'Income',
+          incomeCategory,
+          DateTime(2026, 6, 1).toUtc(),
+          walletId: walletId,
+        );
+
+    Record transfer({
+      required int sourceWalletId,
+      required int destWalletId,
+      required double value,
+      double? transferValue,
+    }) =>
+        Record(
+          value,
+          'Transfer',
+          expenseCategory,
+          DateTime(2026, 6, 1).toUtc(),
+          walletId: sourceWalletId,
+          transferWalletId: destWalletId,
+          transferValue: transferValue,
+        );
+
+    test('empty wallet set returns nothing', () {
+      final records = [
+        expense(walletId: 1, value: -50),
+        transfer(sourceWalletId: 1, destWalletId: 2, value: -30),
+      ];
+      final result =
+          TabRecordsController.applyTransferAwareWalletFilter(records, {});
+      expect(result, isEmpty);
+    });
+
+    test('non-transfer records for unselected wallet are excluded', () {
+      final records = [
+        expense(walletId: 1, value: -50),
+        income(walletId: 2, value: 100),
+      ];
+      final result =
+          TabRecordsController.applyTransferAwareWalletFilter(records, {1});
+      expect(result, hasLength(1));
+      expect(result.first!.walletId, 1);
+    });
+
+    test('filter by source wallet: transfer included with original value', () {
+      final records = [
+        expense(walletId: 1, value: -50),
+        income(walletId: 2, value: 100),
+        transfer(sourceWalletId: 1, destWalletId: 2, value: -30),
+      ];
+      final result =
+          TabRecordsController.applyTransferAwareWalletFilter(records, {1});
+      expect(result, hasLength(2));
+      final t = result[1]!;
+      expect(t.value, -30);
+      expect(t.walletId, 1);
+      expect(t.transferWalletId, 2);
+      expect(t.isDestinationTransferView, false);
+    });
+
+    test(
+        'filter by destination wallet: transfer shown as positive, wallet IDs unchanged',
+        () {
+      final records = [
+        expense(walletId: 1, value: -50),
+        income(walletId: 2, value: 100),
+        transfer(sourceWalletId: 1, destWalletId: 2, value: -30),
+      ];
+      final result =
+          TabRecordsController.applyTransferAwareWalletFilter(records, {2});
+      expect(result, hasLength(2));
+      final t = result[1]!;
+      // value becomes positive received amount
+      expect(t.value, 30);
+      // wallet IDs are NOT swapped — source and destination remain correct
+      expect(t.walletId, 1);
+      expect(t.transferWalletId, 2);
+      expect(t.isDestinationTransferView, true);
+      // original record was not mutated
+      expect(records[2]!.isDestinationTransferView, false);
+    });
+
+    test(
+        'cross-currency transfer: destination view uses transferValue, wallet IDs unchanged',
+        () {
+      // 100 USD leaving wallet 1, 90 EUR arriving at wallet 2
+      final records = [
+        transfer(
+            sourceWalletId: 1,
+            destWalletId: 2,
+            value: -100,
+            transferValue: 90),
+      ];
+      final result =
+          TabRecordsController.applyTransferAwareWalletFilter(records, {2});
+      expect(result, hasLength(1));
+      final t = result.first!;
+      expect(t.value, 90); // transferValue, not negated source value
+      // wallet IDs unchanged — currency widget uses transferWalletId for dest currency
+      expect(t.walletId, 1);
+      expect(t.transferWalletId, 2);
+      expect(t.isDestinationTransferView, true);
+    });
+
+    test(
+        'same-currency transfer: destination view uses value.abs() when transferValue is null',
+        () {
+      final records = [
+        transfer(sourceWalletId: 1, destWalletId: 2, value: -75),
+      ];
+      final result =
+          TabRecordsController.applyTransferAwareWalletFilter(records, {2});
+      expect(result.first!.value, 75);
+    });
+
+    test('both wallets selected: transfer appears once with source perspective',
+        () {
+      final records = [
+        expense(walletId: 1, value: -50),
+        income(walletId: 2, value: 100),
+        transfer(sourceWalletId: 1, destWalletId: 2, value: -30),
+      ];
+      final result =
+          TabRecordsController.applyTransferAwareWalletFilter(records, {1, 2});
+      expect(result, hasLength(3));
+      final t = result[2]!;
+      // Source perspective: unchanged
+      expect(t.value, -30);
+      expect(t.walletId, 1);
+      expect(t.transferWalletId, 2);
+      expect(t.isDestinationTransferView, false);
+    });
+
+    test('transfer with null value does not crash, value stays null', () {
+      final t = Record(
+        null,
+        'Null transfer',
+        expenseCategory,
+        DateTime(2026, 6, 1).toUtc(),
+        walletId: 1,
+        transferWalletId: 2,
+      );
+      final result =
+          TabRecordsController.applyTransferAwareWalletFilter([t], {2});
+      expect(result, hasLength(1));
+      expect(result.first!.value, null);
+      expect(result.first!.isDestinationTransferView, true);
+    });
+
+    test('null record in list is skipped', () {
+      final result =
+          TabRecordsController.applyTransferAwareWalletFilter([null], {1});
+      expect(result, isEmpty);
     });
   });
 }


### PR DESCRIPTION
## Summary

Fixes #358. When filtering records by a wallet, transfer records were invisible if that wallet was the destination rather than the source.

Transfers are stored as a single record (`walletId` = source, `transferWalletId` = destination). The wallet filter only checked `walletId`, so filtering by the destination wallet returned nothing.

## Changes

**`lib/models/record.dart`**
- Added transient `isDestinationTransferView` flag (not persisted to DB)
- Added `copyWith` helper

**`lib/records/controllers/tab_records_controller.dart`**
- Replaced the `walletId`-only filter with `applyTransferAwareWalletFilter`, which returns the record unchanged for a source match and an in-memory copy for a destination-only match. The copy carries the received amount (`transferValue` for cross-currency, `value.abs()` otherwise) and `isDestinationTransferView = true`. When both wallets are selected the transfer appears once via the source match.
- Applied the same fix to the overview records path in `_loadWallets`.

**`lib/records/components/records-per-day-card.dart`**
- Amount widget: when `isDestinationTransferView`, looks up the display currency from `transferWalletId` (destination) instead of `walletId` (source), so cross-currency transfers show the correct currency symbol.
- On tap: destination-view copies carry a modified value, so the edit page always reloads the canonical record from the database by ID to avoid presenting wrong data.

## Behaviour

| Scenario | Before | After |
|---|---|---|
| Filter by source wallet | Shows −100 | Shows −100 — unchanged |
| Filter by destination wallet | **Nothing shown** | Shows **+100** |
| Filter by both wallets | Shows −100 once | Shows −100 once — unchanged |
| All accounts | Shows −100 once | Shows −100 once — unchanged |
| Tap to edit from destination view | — | Opens editor with correct source/destination wallets |

## Testing

8 new unit tests in `tab_records_controller_test.dart` cover: empty set, source filter, destination filter, cross-currency, same-currency fallback, both-wallets deduplication, null value safety, and null record guard.